### PR TITLE
Cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ The screening option was needed due to a bug in the indexing of the one-electron
 I can tell this has been fixed.
 
 The code is not memory friendly, I ran the cc-pVQZ basis set on H2 and saw that the memory usage was ~8GB so be
-careful on how big of a basis set you use. 
+careful on how big of a basis set you use.
+
+I have also added in the DIIS algorithm (I will not lie, completely copied from ChatGPT. You'll find the
+`struct` called `DIISManager` in the `scf.cpp` file.) Does work though when compared with NWChem. The
+expected outcomes of using DIIS is less iterations taken to converge the SCF, and making the convergence
+process smoother. I highly suggest you try out a larger basis set (6-31g, 6-311gss) with H2O and `-d true` vs
+`-d false` to see the difference.
 
 ## Build Instructions
 
@@ -79,13 +85,20 @@ Run the program:
 
 Available options:
 ```bash
-./build/program -h
+❯ ./build/program -h                                            
 Hartree Fock Toy Code
 Usage:
   program [OPTION...]
 
-  -l, --log-level arg  Set logging level [debug, info] (default: info)
-  -h, --help           Print usage
+  -l, --log-level arg       Set logging level [debug, info] (default: info)
+  -f, --xyz-file arg        XYZ File to use (default: h2.xyz)
+  -b, --basis arg           basis set to use (default: sto-3g)
+  -c, --charge arg          charge of system (default: 0)
+  -i, --max-iterations arg  Max number of SCF iterations (default: 20)
+  -t, --tolerance arg       Tolerance for dE during SCF (default: 1e-6)
+  -d, --diis arg            Whether DIIS is enabled or not [true, false] 
+                            (default: true)
+  -h, --help                Print usage
 ```
 
 ### Nix Build
@@ -113,7 +126,7 @@ nix run
 
 If you want to use `nix run` with the available command line arguments, here is how:
 ```bash
-nix run . -- [-h, --help, -l [debug, info], --log-level [debug, info]]
+nix run . -- [-h, --help, -l [debug, info], --log-level [debug, info], etc.]
 # Example: nix run . -- --log-level debug
 ```
 
@@ -122,21 +135,11 @@ nix run . -- [-h, --help, -l [debug, info], --log-level [debug, info]]
 The output should be the following:
 
 ``` bash
-[2025-06-29 11:14:43.272] [ info] Basis: sto-3g
-[2025-06-29 11:14:43.275] [ info] Total energy: -1.0661086493089351
-# NWChem E:                                     -1.066108669518
-[2025-06-29 11:14:43.275] [ info] Basis: sto-6g
-[2025-06-29 11:14:43.281] [ info] Total energy: -1.0735829307648752
-# NWChem E:                                     -1.073582951298
-[2025-06-29 11:14:43.281] [ info] Basis: 3-21g
-[2025-06-29 11:14:43.286] [ info] Total energy: -1.0913860702729483
-# NWChem E:                                     -1.091386084615
-[2025-06-29 11:14:43.286] [ info] Basis: 6-31g
-[2025-06-29 11:14:43.289] [ info] Total energy: -1.0948079614680448
-# NWChem E:                                     -1.094807976031
-[2025-06-29 11:14:43.289] [ info] Basis: 6-311gss
-[2025-06-29 11:14:43.349] [ info] Total energy: -1.1015899868969445
-# NWChem E:                                     -1.101590002337
+./build/program
+[2025-06-29 16:06:38.864] [ info] Using XYZ File: h2.xyz
+[2025-06-29 16:06:38.864] [ info] Basis: sto-3g
+[2025-06-29 16:06:38.868] [ info] Total energy: -1.0661086493089351
+# NWChem Energy (default scf settings):         -1.066108669518
 ```
 
 # References
@@ -147,7 +150,4 @@ up-to-Date Resource for the Molecular Sciences Community.”</span>
 <a
 href="https://doi.org/10.1021/acs.jcim.9b00725">https://doi.org/10.1021/acs.jcim.9b00725</a>.
 
-STO-3G, STO-6G Reference: [Ref](https://www.basissetexchange.org/references/sto-6g/format/txt/?version=1&elements=1)  
-3-21G Reference: [Ref](https://www.basissetexchange.org/references/3-21g/format/txt/?version=1&elements=1)  
-6-31G Reference: [Ref](https://www.basissetexchange.org/references/6-31g/format/txt/?version=1&elements=1)  
-6-311G** Reference: [Ref](https://www.basissetexchange.org/references/6-311g**/format/txt/?version=0&elements=1)
+STO-3G Reference: [Ref](https://www.basissetexchange.org/references/sto-3g/format/txt/?version=1&elements=1)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ concepts of the Hartree Fock equation. It is in no way performant. All I have re
 that the values I am getting for the energies make sense when compared to the values from
 [NWChem](https://github.com/nwchemgit/nwchem) for the same H2 system and basis set.
 
-Currently the code is set up to use the STO-3G, STO-6G, 3-21G, 6-31G, and 6-311G** basis sets,
-based on the values available from the Libint library. Whatever basis sets are available in Libint are
-available for use in this code.
+Currently the code is set up to use the [basis sets available](https://github.com/evaleev/libint/tree/master/lib/basis)
+from the Libint library that you have installed, based on the values available from the Libint library.
+Whatever basis sets are available in Libint are available for use in this code.
 
 ## Important Notes
 Most of this code is "vibe" coded, meaning that I utilized ChatGPT to help understand logic,
@@ -42,8 +42,8 @@ careful on how big of a basis set you use.
 I have also added in the DIIS algorithm (I will not lie, completely copied from ChatGPT. You'll find the
 `struct` called `DIISManager` in the `scf.cpp` file.) Does work though when compared with NWChem. The
 expected outcomes of using DIIS is less iterations taken to converge the SCF, and making the convergence
-process smoother. I highly suggest you try out a larger basis set (6-31g, 6-311gss) with H2O and `-d true` vs
-`-d false` to see the difference.
+process smoother. I highly suggest you try out a larger basis set (6-31g, 6-311gss) with H2O and `-l debug -d true`
+vs `-l debug -d false` to see the difference.
 
 ## Build Instructions
 
@@ -96,9 +96,19 @@ Usage:
   -c, --charge arg          charge of system (default: 0)
   -i, --max-iterations arg  Max number of SCF iterations (default: 20)
   -t, --tolerance arg       Tolerance for dE during SCF (default: 1e-6)
-  -d, --diis arg            Whether DIIS is enabled or not [true, false] 
-                            (default: true)
+  -d, --diis arg            DIIS enabled: [true, false] (default: true)
   -h, --help                Print usage
+```
+
+Default run:
+```bash
+./build/program --log-level info \
+--xyz-file h2.xyz \
+--basis sto-3g \
+--charge 0 \
+--max-iterations 20 \
+--tolerance 1e-6 \
+--diis true
 ```
 
 ### Nix Build

--- a/include/energy.hpp
+++ b/include/energy.hpp
@@ -9,6 +9,6 @@ using matrix2d = Eigen::MatrixXd;
 double
 nuclear_nuclear_repulsion_energy(std::vector<libint2::Atom> atoms);
 
-double compute_electronic_energy_expectation_value(matrix2d dens_mat,
+std::array<double, 3> compute_electronic_energy_expectation_value(matrix2d dens_mat,
                                                    matrix2d T, matrix2d Vne,
                                                    matrix2d G);

--- a/include/scf.hpp
+++ b/include/scf.hpp
@@ -8,4 +8,5 @@ using matrix2d = Eigen::MatrixXd;
 
 double
 scf_cycle(std::tuple<matrix2d, matrix2d, matrix2d, tensor4d> molecular_terms,
-          std::tuple<double, int> scf_parameters, libint2::BasisSet obs, std::vector<libint2::Atom> atoms, int charge = 0);
+          std::tuple<double, uint> scf_parameters, libint2::BasisSet obs, std::vector<libint2::Atom> atoms, int charge = 0,
+bool diis_enabled = true);

--- a/src/energy.cpp
+++ b/src/energy.cpp
@@ -23,7 +23,7 @@ nuclear_nuclear_repulsion_energy(std::vector<libint2::Atom> atoms) {
   return E_NN;
 }
 
-double compute_electronic_energy_expectation_value(matrix2d dens_mat,
+std::array<double, 3> compute_electronic_energy_expectation_value(matrix2d dens_mat,
                                                    matrix2d T, matrix2d Vne,
                                                    matrix2d G) {
 
@@ -40,5 +40,5 @@ double compute_electronic_energy_expectation_value(matrix2d dens_mat,
       electronic_energy += dens_mat(i,j) * (Hcore(i,j) + 0.5 * G(i,j));
     }
   }
-  return electronic_energy;
+  return {electronic_energy, E_one, E_two};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,12 +17,28 @@ std::string to_string_ten(const Eigen::Tensor<double, 4>& ten) {
 
 int main(int argc, char* argv[]) {
   std::string  xyz_file, basis;
+  uint max_iterations = 20;
+  double tolerance = 1e-6;
+  bool diis_enabled = true;
+  int charge = 0;
+  
   try {
+    std::map<std::string, spdlog::level::level_enum> log_levels = {
+      {"debug", spdlog::level::debug},
+      {"info", spdlog::level::info},
+      {"warn", spdlog::level::warn},
+      {"error", spdlog::level::err},
+      {"trace", spdlog::level::trace}
+    };
     cxxopts::Options options("program", "Hartree Fock Toy Code");
     options.add_options()
       ("l,log-level", "Set logging level [debug, info]", cxxopts::value<std::string>()->default_value("info"))
       ("f,xyz-file", "XYZ File to use", cxxopts::value<std::string>()->default_value("h2.xyz"))
       ("b,basis", "basis set to use", cxxopts::value<std::string>()->default_value("sto-3g"))
+      ("c,charge", "charge of system", cxxopts::value<int>()->default_value("0"))
+      ("i,max-iterations", "Max number of SCF iterations", cxxopts::value<unsigned int>()->default_value("20"))
+      ("t,tolerance", "Tolerance for dE during SCF", cxxopts::value<double>()->default_value("1e-6"))
+      ("d,diis", "Whether DIIS is enabled or not [true, false]", cxxopts::value<std::string>()->default_value("true"))
       ("h,help", "Print usage");
     auto result = options.parse(argc, argv);
 
@@ -34,16 +50,19 @@ int main(int argc, char* argv[]) {
     std::string log_level = result["log-level"].as<std::string>();
     xyz_file = result["xyz-file"].as<std::string>();
     basis = result["basis"].as<std::string>();
-    
-    if (log_level != "debug" && log_level != "info") {
+    max_iterations = result["max-iterations"].as<unsigned int>();
+    tolerance = result["tolerance"].as<double>();
+    if (result["diis"].as<std::string>() == "false") {
+      diis_enabled = false;
+    }
+    charge = result["charge"].as<int>();
+
+    auto it = log_levels.find(log_level);
+    if (it != log_levels.end()) {
+      spdlog::set_level(it->second);
+    } else {
       spdlog::error("Unknown logging level: {}", log_level);
       return 1;
-    }
-
-    if (log_level == "debug") {
-      spdlog::set_level(spdlog::level::debug);
-    } else {
-      spdlog::set_level(spdlog::level::info);
     }
   } catch (const cxxopts::exceptions::exception& e) {
       spdlog::error("Error parsing options: {}", e.what());
@@ -64,6 +83,10 @@ int main(int argc, char* argv[]) {
 
   spdlog::info("Basis: {}", basis);
   libint2::BasisSet obs(basis, atoms);
+  if (obs.size() == 0) {
+    spdlog::error("Invalid Basis Set: {}", basis);
+    return 1;
+  }
   auto S = overlap(obs);
   spdlog::trace("\nOverlap Matrix:\n{}", to_string_mat(S));
   auto T = kinetic(obs);
@@ -73,11 +96,11 @@ int main(int argc, char* argv[]) {
   auto V_ee = electron_electron_repulsion(obs);
   spdlog::trace("\nV_ee Matrix:\n{}", to_string_ten(V_ee));
   auto E_NN = nuclear_nuclear_repulsion_energy(atoms);
-  spdlog::debug("E_nn Value: {}", E_NN);
   auto molecular_terms = std::make_tuple(S, T, V_ne, V_ee);
-  auto scf_parameters = std::make_tuple(1e-8, 50);
-  auto electronic_energy = scf_cycle(molecular_terms, scf_parameters, obs, atoms);
+  auto scf_parameters = std::make_tuple(tolerance, max_iterations);
+  auto electronic_energy = scf_cycle(molecular_terms, scf_parameters, obs, atoms, charge, diis_enabled);
   spdlog::debug("Electronic Energy: {}", electronic_energy);
+  spdlog::debug("E_nn Value: {}", E_NN);
   auto total_energy = electronic_energy + E_NN;
 
   spdlog::info("Total energy: {:.16f}", total_energy);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
       ("c,charge", "charge of system", cxxopts::value<int>()->default_value("0"))
       ("i,max-iterations", "Max number of SCF iterations", cxxopts::value<unsigned int>()->default_value("20"))
       ("t,tolerance", "Tolerance for dE during SCF", cxxopts::value<double>()->default_value("1e-6"))
-      ("d,diis", "Whether DIIS is enabled or not [true, false]", cxxopts::value<std::string>()->default_value("true"))
+      ("d,diis", "DIIS enabled: [true, false]", cxxopts::value<std::string>()->default_value("true"))
       ("h,help", "Print usage");
     auto result = options.parse(argc, argv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,10 +16,13 @@ std::string to_string_ten(const Eigen::Tensor<double, 4>& ten) {
 }
 
 int main(int argc, char* argv[]) {
+  std::string  xyz_file, basis;
   try {
     cxxopts::Options options("program", "Hartree Fock Toy Code");
     options.add_options()
       ("l,log-level", "Set logging level [debug, info]", cxxopts::value<std::string>()->default_value("info"))
+      ("f,xyz-file", "XYZ File to use", cxxopts::value<std::string>()->default_value("h2.xyz"))
+      ("b,basis", "basis set to use", cxxopts::value<std::string>()->default_value("sto-3g"))
       ("h,help", "Print usage");
     auto result = options.parse(argc, argv);
 
@@ -29,6 +32,9 @@ int main(int argc, char* argv[]) {
     }
 
     std::string log_level = result["log-level"].as<std::string>();
+    xyz_file = result["xyz-file"].as<std::string>();
+    basis = result["basis"].as<std::string>();
+    
     if (log_level != "debug" && log_level != "info") {
       spdlog::error("Unknown logging level: {}", log_level);
       return 1;
@@ -46,42 +52,36 @@ int main(int argc, char* argv[]) {
   
   spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%5l%$] %v");
 
+  std::ifstream xyz(xyz_file);
+  spdlog::info("Using XYZ File: {}", xyz_file);
+  if (!xyz) {
+    spdlog::error("XYZ File not found: {}", xyz_file);
+    return 1;
+  }
+
   libint2::initialize();
-
-  std::vector<std::string> basis_sets;
-  basis_sets.push_back("sto-3g");
-  basis_sets.push_back("sto-6g");
-  basis_sets.push_back("3-21g");
-  basis_sets.push_back("6-31g");
-  basis_sets.push_back("6-311gss");
-  // basis_sets.push_back("cc-pvqz");
-  // basis_sets.push_back("cc-pv6z");
-
-
-  std::ifstream xyz("h2.xyz");
   std::vector<libint2::Atom> atoms = libint2::read_dotxyz(xyz);
 
-  for (std::string basis : basis_sets) {
-    spdlog::info("Basis: {}", basis);
-    libint2::BasisSet obs(basis, atoms);
-    auto S = overlap(obs);
-    spdlog::trace("\nOverlap Matrix:\n{}", to_string_mat(S));
-    auto T = kinetic(obs);
-    spdlog::trace("\nKinetic Matrix:\n{}", to_string_mat(T));
-    auto V_ne = electron_nuclear_attraction(obs, atoms);
-    spdlog::trace("\nV_ne Matrix:\n{}", to_string_mat(V_ne));
-    auto V_ee = electron_electron_repulsion(obs);
-    spdlog::trace("\nV_ee Matrix:\n{}", to_string_ten(V_ee));
-    auto E_NN = nuclear_nuclear_repulsion_energy(atoms);
-    spdlog::debug("E_nn Value: {}", E_NN);
-    auto molecular_terms = std::make_tuple(S, T, V_ne, V_ee);
-    auto scf_parameters = std::make_tuple(1e-8, 50);
-    auto electronic_energy = scf_cycle(molecular_terms, scf_parameters, obs, atoms);
-    spdlog::debug("Electronic Energy: {}", electronic_energy);
-    auto total_energy = electronic_energy + E_NN;
+  spdlog::info("Basis: {}", basis);
+  libint2::BasisSet obs(basis, atoms);
+  auto S = overlap(obs);
+  spdlog::trace("\nOverlap Matrix:\n{}", to_string_mat(S));
+  auto T = kinetic(obs);
+  spdlog::trace("\nKinetic Matrix:\n{}", to_string_mat(T));
+  auto V_ne = electron_nuclear_attraction(obs, atoms);
+  spdlog::trace("\nV_ne Matrix:\n{}", to_string_mat(V_ne));
+  auto V_ee = electron_electron_repulsion(obs);
+  spdlog::trace("\nV_ee Matrix:\n{}", to_string_ten(V_ee));
+  auto E_NN = nuclear_nuclear_repulsion_energy(atoms);
+  spdlog::debug("E_nn Value: {}", E_NN);
+  auto molecular_terms = std::make_tuple(S, T, V_ne, V_ee);
+  auto scf_parameters = std::make_tuple(1e-8, 50);
+  auto electronic_energy = scf_cycle(molecular_terms, scf_parameters, obs, atoms);
+  spdlog::debug("Electronic Energy: {}", electronic_energy);
+  auto total_energy = electronic_energy + E_NN;
 
-    spdlog::info("Total energy: {:.16f}", total_energy);
-  }
+  spdlog::info("Total energy: {:.16f}", total_energy);
+
   libint2::finalize();
   return 0;
 }

--- a/src/scf.cpp
+++ b/src/scf.cpp
@@ -1,13 +1,56 @@
 #include <scf.hpp>
 #include <density.hpp>
 #include <energy.hpp>
+#include <spdlog/spdlog.h>
+
+struct DIISManager {
+  std::vector<matrix2d> fock_history;
+  std::vector<matrix2d> error_history;
+  int max_diis = 6;
+
+  void add(const matrix2d& fock, const matrix2d& error) {
+    fock_history.push_back(fock);
+    error_history.push_back(error);
+
+    if (fock_history.size() > max_diis) {
+      fock_history.erase(fock_history.begin());
+      error_history.erase(error_history.begin());
+    }
+  }
+
+  matrix2d extrapolate() {
+    int n = error_history.size();
+    Eigen::MatrixXd B = Eigen::MatrixXd::Zero(n + 1, n + 1);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(n + 1);
+    rhs(n) = -1.0;
+
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < n; j++) {
+        B(i, j) = (error_history[i].array() * error_history[j].array()).sum();
+      }
+      B(i, n) = B(n, i) = -1.0;
+    }
+
+    Eigen::VectorXd coeffs = B.fullPivLu().solve(rhs);
+
+    matrix2d fock_new = matrix2d::Zero(fock_history[0].rows(), fock_history[0].cols());
+    for (int i = 0; i < n; i++) {
+      fock_new += coeffs(i) * fock_history[i];
+    }
+    return fock_new;
+  }
+
+  bool ready() const { return fock_history.size() >= 2; }
+};
 
 double
 scf_cycle(std::tuple<matrix2d, matrix2d, matrix2d, tensor4d> molecular_terms,
-          std::tuple<double, int> scf_parameters, libint2::BasisSet obs, std::vector<libint2::Atom> atoms, int charge) {
+          std::tuple<double, uint> scf_parameters, libint2::BasisSet obs, std::vector<libint2::Atom> atoms, int charge, bool diis_enabled) {
   auto [S, T, Vne, Vee] = molecular_terms;
   auto [tolerance, max_iter] = scf_parameters;
   auto electronic_energy = 0.0;
+  bool converged = false;
+  DIISManager diis;
 
   int nbasis_functions = obs.nbf();
   matrix2d dens_mat(nbasis_functions, nbasis_functions);
@@ -20,28 +63,33 @@ scf_cycle(std::tuple<matrix2d, matrix2d, matrix2d, tensor4d> molecular_terms,
   electrons -= charge;
   int n_occ = electrons / 2;
 
+  Eigen::SelfAdjointEigenSolver<matrix2d> es(S);
+  if (es.info() != Eigen::Success) {
+    throw std::runtime_error("Man this stuff sucks at S");
+  }
+
+  Eigen::VectorXd evals = es.eigenvalues();
+  Eigen::MatrixXd evecs = es.eigenvectors();
+
+  for (int i = 0; i < evals.size(); i++) {
+      evals[i] = 1.0 / std::sqrt(evals[i]);
+  }
+
+  matrix2d S_inv_sqrt = evecs * evals.asDiagonal() * evecs.transpose();
+
   for (int scf_step = 0; scf_step < max_iter; scf_step++) {
     auto electronic_energy_old = electronic_energy;
     auto G = compute_G(dens_mat, Vee);
-    auto F = T + Vne + G;
+    auto F = (T + Vne + G).eval();
 
-    Eigen::SelfAdjointEigenSolver<matrix2d> es(S);
-    if (es.info() != Eigen::Success) {
-      throw std::runtime_error("Man this stuff sucks at S");
+    matrix2d err = F * dens_mat * S - S * dens_mat * F;
+    if (scf_step > 0) {
+      diis.add(F, err);
     }
 
-    Eigen::VectorXd evals = es.eigenvalues();
-    Eigen::MatrixXd evecs = es.eigenvectors();
-
-
-    double cond_number = es.eigenvalues().maxCoeff() / es.eigenvalues().minCoeff();
-
-    double eps = 1e-12;
-
-    for (int i = 0; i < evals.size(); i++) {
-        evals[i] = 1.0 / std::sqrt(evals[i]);
+    if (diis_enabled && diis.ready()) {
+      F = diis.extrapolate();
     }
-    matrix2d S_inv_sqrt = evecs * evals.asDiagonal() * evecs.transpose();
 
     matrix2d F_unitS = S_inv_sqrt * F * S_inv_sqrt;
     matrix2d F_unitS_eigen = F_unitS;
@@ -59,12 +107,24 @@ scf_cycle(std::tuple<matrix2d, matrix2d, matrix2d, tensor4d> molecular_terms,
 
     dens_mat = compute_density_matrix(mos, n_occ);
 
-    electronic_energy =
+    auto [E_energy, E_one, E_two] =
         compute_electronic_energy_expectation_value(dens_mat, T, Vne, G);
+    electronic_energy = E_energy;
 
-    if (std::fabs(electronic_energy - electronic_energy_old) < tolerance) {
+    double de = electronic_energy - electronic_energy_old;
+    bool using_diis = (diis_enabled && diis.ready());
+
+    spdlog::debug("SCF Step: {}\tDIIS Enabled: {}\tElectronic Energy: {}\tdE: {}", scf_step, using_diis, electronic_energy, de);
+
+    if (std::fabs(de) < tolerance) {
+      converged = true;
+      spdlog::debug("One-electron Energy: {}", E_one);
+      spdlog::debug("Two-electron Energy: {}", E_two);
       break;
     }
+  }
+  if (!converged) {
+    spdlog::warn("SCF did not converge, values are not accurate!");
   }
   return electronic_energy;
 }


### PR DESCRIPTION
This pull request does the following:

- adds DIIS
- adds and cleans up CLI options
- changes the `compute_electronic_energy_expectation_value` function to return a `std::array<double, 3>` of the electronic energy, the one-electron energy, and the two-electron energy
- `main` now only runs one calculation instead of looping over several.